### PR TITLE
Hardcoded continuation prompt implementation with `continuation_prompt` feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,13 +48,13 @@ jobs:
         run: cargo check --workspace --no-default-features
         env:
           RUSTFLAGS: "-D warnings"
-      - name: Check split-highlight feature
-        run: |
-          cargo check --workspace --all-targets --features 'split-highlight'
-          cargo check --workspace --all-targets --features 'split-highlight ansi-str'
-          cargo check --workspace --all-targets --features 'split-highlight anstyle'
-          cargo check --workspace --all-targets --features 'split-highlight ansi-str derive'
-          cargo check --workspace --all-targets --features 'split-highlight anstyle derive'
+      # - name: Check split-highlight feature
+      #   run: |
+      #     cargo check --workspace --all-targets --features 'split-highlight'
+      #     cargo check --workspace --all-targets --features 'split-highlight ansi-str'
+      #     cargo check --workspace --all-targets --features 'split-highlight anstyle'
+      #     cargo check --workspace --all-targets --features 'split-highlight ansi-str derive'
+      #     cargo check --workspace --all-targets --features 'split-highlight anstyle derive'
 
   direct-minimal-versions:
     name: Test min versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ name = "sqlite_history"
 required-features = ["with-sqlite-history"]
 [[example]]
 name = "continuation_prompt"
-required-features = ["custom-bindings", "derive", "continuation-prompt", "split-highlight"]
+required-features = ["custom-bindings", "derive", "split-highlight"]
 
 [package.metadata.docs.rs]
 features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ with-sqlite-history = ["rusqlite"]
 with-fuzzy = ["skim"]
 case_insensitive_history_search = ["regex"]
 # For continuation prompt, indentation, scrolling
-split-highlight = []
+# split-highlight = []
 
 [[example]]
 name = "custom_key_bindings"
@@ -99,7 +99,7 @@ name = "sqlite_history"
 required-features = ["with-sqlite-history"]
 [[example]]
 name = "continuation_prompt"
-required-features = ["custom-bindings", "derive", "split-highlight"]
+required-features = ["custom-bindings", "derive"]
 
 [package.metadata.docs.rs]
 features = [
@@ -108,8 +108,8 @@ features = [
     "with-dirs",
     "with-file-history",
     "with-fuzzy",
-    "split-highlight",
-    "anstyle",
+    # "split-highlight",
+    # "anstyle",
 ]
 all-features = false
 no-default-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ with-fuzzy = ["skim"]
 case_insensitive_history_search = ["regex"]
 # For continuation prompt, indentation, scrolling
 split-highlight = []
-continuation-prompt = []
 
 [[example]]
 name = "custom_key_bindings"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = ["rustyline-derive"]
 # For convenience / compatibilty, you can highlight the whole input buffer, ansi-str helps to split
 ansi-str = { version = "0.8.0", optional = true }
 # ansi_str::Style is immutable so we use anstyle::Style instead
-anstyle = { version = "1.0.8", optional = true }
+anstyle = "1.0.8"
 bitflags = "2.6"
 cfg-if = "1.0"
 # For file completion

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ with-fuzzy = ["skim"]
 case_insensitive_history_search = ["regex"]
 # For continuation prompt, indentation, scrolling
 split-highlight = []
+continuation-prompt = []
 
 [[example]]
 name = "custom_key_bindings"
@@ -97,6 +98,9 @@ required-features = ["derive"]
 [[example]]
 name = "sqlite_history"
 required-features = ["with-sqlite-history"]
+[[example]]
+name = "continuation_prompt"
+required-features = ["custom-bindings", "derive", "continuation-prompt", "split-highlight"]
 
 [package.metadata.docs.rs]
 features = [

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ use rustyline::{DefaultEditor, Result};
 
 fn main() -> Result<()> {
     // `()` can be used when no completer is required
-    let mut rl = DefaultEditor::new()?;
+    // Use `new(())` for default Helper.
+    let mut rl = DefaultEditor::new(())?;
     #[cfg(feature = "with-file-history")]
     if rl.load_history("history.txt").is_err() {
         println!("No previous history.");

--- a/examples/continuation_prompt.rs
+++ b/examples/continuation_prompt.rs
@@ -1,4 +1,4 @@
-use rustyline::highlight::Highlighter;
+use rustyline::highlight::{DisplayOnce, Highlighter, StyledBlocks};
 use rustyline::validate::{ValidationContext, ValidationResult, Validator};
 use rustyline::{Cmd, Editor, EventHandler, Helper, KeyCode, KeyEvent, Modifiers, Result};
 use rustyline::{Completer, Hinter};
@@ -48,17 +48,17 @@ impl Highlighter for InputValidator {
     fn highlight_char(&mut self, _line: &str, _pos: usize, _forced: bool) -> bool {
         self.need_render
     }
-    #[cfg(feature = "split-highlight")]
-    fn highlight_line<'l>(
-        &mut self,
+    fn highlight<'b, 's: 'b, 'l: 'b>(
+        &'s mut self,
         line: &'l str,
         _pos: usize,
-    ) -> impl Iterator<Item = impl 'l + rustyline::highlight::StyledBlock> {
+    ) -> impl 'b + DisplayOnce {
         use core::iter::once;
         let mut lines = line.split('\n');
         self.need_render = false;
-        once(((), lines.next().unwrap()))
-            .chain(lines.flat_map(|line| once(((), "\n.. ")).chain(once(((), line)))))
+        let iter = once(((), lines.next().unwrap()))
+            .chain(lines.flat_map(|line| once(((), "\n.. ")).chain(once(((), line)))));
+        StyledBlocks::new(iter)
     }
 }
 

--- a/examples/continuation_prompt.rs
+++ b/examples/continuation_prompt.rs
@@ -45,6 +45,7 @@ impl Highlighter for InputValidator {
     fn highlight_char(&mut self, _line: &str, _pos: usize, _forced: bool) -> bool {
         self.need_render
     }
+    #[cfg(feature = "split-highlight")]
     fn highlight_line<'l>(
         &mut self,
         line: &'l str,

--- a/examples/continuation_prompt.rs
+++ b/examples/continuation_prompt.rs
@@ -1,0 +1,76 @@
+use rustyline::highlight::Highlighter;
+use rustyline::validate::{ValidationContext, ValidationResult, Validator};
+use rustyline::{Cmd, Editor, EventHandler, Helper, KeyCode, KeyEvent, Modifiers, Result};
+use rustyline::{Completer, Hinter};
+
+#[derive(Completer, Hinter)]
+struct InputValidator {
+    bracket_level: i32,
+    /// re-render only when input just changed
+    /// not render after cursor moving
+    need_render: bool,
+}
+
+impl Helper for InputValidator {
+    fn update_after_edit(&mut self, line: &str, _pos: usize, _forced_refresh: bool) {
+        self.bracket_level = line.chars().fold(0, |level, c| {
+            if c == '(' {
+                level + 1
+            } else if c == ')' {
+                level - 1
+            } else {
+                level
+            }
+        });
+        self.need_render = true;
+    }
+}
+
+impl Validator for InputValidator {
+    fn validate(&mut self, _ctx: &mut ValidationContext) -> Result<ValidationResult> {
+        if self.bracket_level > 0 {
+            Ok(ValidationResult::Incomplete(2))
+        } else if self.bracket_level < 0 {
+            Ok(ValidationResult::Invalid(Some(format!(
+                " - excess {} close bracket",
+                -self.bracket_level
+            ))))
+        } else {
+            Ok(ValidationResult::Valid(None))
+        }
+    }
+}
+
+impl Highlighter for InputValidator {
+    fn highlight_char(&mut self, _line: &str, _pos: usize, _forced: bool) -> bool {
+        self.need_render
+    }
+    fn highlight_line<'l>(
+        &mut self,
+        line: &'l str,
+        _pos: usize,
+    ) -> impl Iterator<Item = impl 'l + rustyline::highlight::StyledBlock> {
+        use core::iter::once;
+        let mut lines = line.split('\n');
+        self.need_render = false;
+        once(((), lines.next().unwrap()))
+            .chain(lines.flat_map(|line| once(((), "\n.. ")).chain(once(((), line)))))
+    }
+}
+
+fn main() -> Result<()> {
+    let h = InputValidator {
+        bracket_level: 0,
+        need_render: true,
+    };
+    let mut rl = Editor::new(h)?;
+    rl.bind_sequence(
+        KeyEvent(KeyCode::Char('s'), Modifiers::CTRL),
+        EventHandler::Simple(Cmd::Newline),
+    );
+
+    let input = rl.readline(">> ")?;
+    println!("Input: {input}");
+
+    Ok(())
+}

--- a/examples/continuation_prompt.rs
+++ b/examples/continuation_prompt.rs
@@ -24,6 +24,9 @@ impl Helper for InputValidator {
         });
         self.need_render = true;
     }
+    fn continuation_prompt_width<'b, 's: 'b, 'p: 'b>(&'s self, prompt: &'p str) -> usize {
+        3
+    }
 }
 
 impl Validator for InputValidator {

--- a/examples/custom_key_bindings.rs
+++ b/examples/custom_key_bindings.rs
@@ -25,7 +25,7 @@ impl Highlighter for MyHelper {
         }
     }
 
-    fn highlight_hint<'h>(&mut self, hint: &'h str) -> Cow<'h, str> {
+    fn highlight_hint<'b, 's: 'b, 'h: 'b>(&'s mut self, hint: &'h str) -> Cow<'b, str> {
         Owned(format!("\x1b[1m{hint}\x1b[m"))
     }
 }

--- a/examples/custom_key_bindings.rs
+++ b/examples/custom_key_bindings.rs
@@ -14,7 +14,7 @@ struct MyHelper(#[rustyline(Hinter)] HistoryHinter);
 
 impl Highlighter for MyHelper {
     fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
-        &'s self,
+        &'s mut self,
         prompt: &'p str,
         default: bool,
     ) -> Cow<'b, str> {
@@ -25,7 +25,7 @@ impl Highlighter for MyHelper {
         }
     }
 
-    fn highlight_hint<'h>(&self, hint: &'h str) -> Cow<'h, str> {
+    fn highlight_hint<'h>(&mut self, hint: &'h str) -> Cow<'h, str> {
         Owned(format!("\x1b[1m{hint}\x1b[m"))
     }
 }
@@ -85,8 +85,7 @@ impl ConditionalEventHandler for TabEventHandler {
 }
 
 fn main() -> Result<()> {
-    let mut rl = Editor::<MyHelper, DefaultHistory>::new()?;
-    rl.set_helper(Some(MyHelper(HistoryHinter::new())));
+    let mut rl = Editor::<MyHelper, DefaultHistory>::new(MyHelper(HistoryHinter::new()))?;
 
     let ceh = Box::new(CompleteHintHandler);
     rl.bind_sequence(KeyEvent::ctrl('E'), EventHandler::Conditional(ceh.clone()));

--- a/examples/diy_hints.rs
+++ b/examples/diy_hints.rs
@@ -52,7 +52,7 @@ impl CommandHint {
 impl Hinter for DIYHinter {
     type Hint = CommandHint;
 
-    fn hint(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Option<CommandHint> {
+    fn hint(&mut self, line: &str, pos: usize, _ctx: &Context<'_>) -> Option<CommandHint> {
         if line.is_empty() || pos < line.len() {
             return None;
         }
@@ -86,8 +86,7 @@ fn main() -> Result<()> {
     println!("This is a DIY hint hack of rustyline");
     let h = DIYHinter { hints: diy_hints() };
 
-    let mut rl: Editor<DIYHinter, DefaultHistory> = Editor::new()?;
-    rl.set_helper(Some(h));
+    let mut rl: Editor<DIYHinter, DefaultHistory> = Editor::new(h)?;
 
     loop {
         let input = rl.readline("> ")?;

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow::{self, Borrowed, Owned};
 
 use rustyline::completion::FilenameCompleter;
 use rustyline::error::ReadlineError;
-use rustyline::highlight::{Highlighter, MatchingBracketHighlighter};
+use rustyline::highlight::{DisplayOnce, Highlighter, MatchingBracketHighlighter};
 use rustyline::hint::HistoryHinter;
 use rustyline::validate::MatchingBracketValidator;
 use rustyline::{Cmd, CompletionType, Config, EditMode, Editor, KeyEvent};
@@ -33,22 +33,16 @@ impl Highlighter for MyHelper {
         }
     }
 
-    fn highlight_hint<'h>(&mut self, hint: &'h str) -> Cow<'h, str> {
+    fn highlight_hint<'b, 's: 'b, 'h: 'b>(&'s mut self, hint: &'h str) -> Cow<'b, str> {
         Owned("\x1b[1m".to_owned() + hint + "\x1b[m")
     }
 
-    #[cfg(not(feature = "split-highlight"))]
-    fn highlight<'l>(&mut self, line: &'l str, pos: usize) -> Cow<'l, str> {
-        self.highlighter.highlight(line, pos)
-    }
-
-    #[cfg(feature = "split-highlight")]
-    fn highlight_line<'l>(
-        &mut self,
+    fn highlight<'b, 's: 'b, 'l: 'b>(
+        &'s mut self,
         line: &'l str,
         pos: usize,
-    ) -> impl Iterator<Item = impl 'l + rustyline::highlight::StyledBlock> {
-        self.highlighter.highlight_line(line, pos)
+    ) -> impl 'b + DisplayOnce {
+        self.highlighter.highlight(line, pos)
     }
 
     fn highlight_char(&mut self, line: &str, pos: usize, forced: bool) -> bool {

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -37,12 +37,12 @@ impl Highlighter for MyHelper {
         Owned("\x1b[1m".to_owned() + hint + "\x1b[m")
     }
 
-    #[cfg(any(not(feature = "split-highlight"), feature = "ansi-str"))]
+    #[cfg(not(feature = "split-highlight"))]
     fn highlight<'l>(&mut self, line: &'l str, pos: usize) -> Cow<'l, str> {
         self.highlighter.highlight(line, pos)
     }
 
-    #[cfg(all(feature = "split-highlight", not(feature = "ansi-str")))]
+    #[cfg(feature = "split-highlight")]
     fn highlight_line<'l>(
         &mut self,
         line: &'l str,

--- a/examples/external_print.rs
+++ b/examples/external_print.rs
@@ -6,7 +6,7 @@ use rand::{thread_rng, Rng};
 use rustyline::{DefaultEditor, ExternalPrinter, Result};
 
 fn main() -> Result<()> {
-    let mut rl = DefaultEditor::new()?;
+    let mut rl = DefaultEditor::new(())?;
     let mut printer = rl.create_external_printer()?;
     thread::spawn(move || {
         let mut rng = thread_rng();

--- a/examples/input_multiline.rs
+++ b/examples/input_multiline.rs
@@ -16,8 +16,7 @@ fn main() -> Result<()> {
         brackets: MatchingBracketValidator::new(),
         highlighter: MatchingBracketHighlighter::new(),
     };
-    let mut rl = Editor::new()?;
-    rl.set_helper(Some(h));
+    let mut rl = Editor::new(h)?;
     rl.bind_sequence(
         KeyEvent(KeyCode::Char('s'), Modifiers::CTRL),
         EventHandler::Simple(Cmd::Newline),

--- a/examples/input_multiline.rs
+++ b/examples/input_multiline.rs
@@ -1,4 +1,4 @@
-use rustyline::highlight::MatchingBracketHighlighter;
+use rustyline::highlight::{DisplayOnce, MatchingBracketHighlighter};
 use rustyline::validate::MatchingBracketValidator;
 use rustyline::{Cmd, Editor, EventHandler, KeyCode, KeyEvent, Modifiers, Result};
 use rustyline::{Completer, Helper, Highlighter, Hinter, Validator};

--- a/examples/input_validation.rs
+++ b/examples/input_validation.rs
@@ -6,13 +6,13 @@ use rustyline::{Editor, Result};
 struct InputValidator {}
 
 impl Validator for InputValidator {
-    fn validate(&self, ctx: &mut ValidationContext) -> Result<ValidationResult> {
+    fn validate(&mut self, ctx: &mut ValidationContext) -> Result<ValidationResult> {
         use ValidationResult::{Incomplete, Invalid, Valid};
         let input = ctx.input();
         let result = if !input.starts_with("SELECT") {
             Invalid(Some(" --< Expect: SELECT stmt".to_owned()))
         } else if !input.ends_with(';') {
-            Incomplete
+            Incomplete(0)
         } else {
             Valid(None)
         };
@@ -22,8 +22,7 @@ impl Validator for InputValidator {
 
 fn main() -> Result<()> {
     let h = InputValidator {};
-    let mut rl = Editor::new()?;
-    rl.set_helper(Some(h));
+    let mut rl = Editor::new(h)?;
 
     let input = rl.readline("> ")?;
     println!("Input: {input}");

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -3,7 +3,7 @@ use rustyline::{DefaultEditor, Result};
 /// Minimal REPL
 fn main() -> Result<()> {
     env_logger::init();
-    let mut rl = DefaultEditor::new()?;
+    let mut rl = DefaultEditor::new(())?;
     loop {
         let line = rl.readline("> ")?; // read
         println!("Line: {line}"); // eval / print

--- a/examples/numeric_input.rs
+++ b/examples/numeric_input.rs
@@ -19,7 +19,7 @@ impl ConditionalEventHandler for FilteringEventHandler {
 }
 
 fn main() -> Result<()> {
-    let mut rl = DefaultEditor::new()?;
+    let mut rl = DefaultEditor::new(())?;
 
     rl.bind_sequence(
         Event::Any,

--- a/examples/read_password.rs
+++ b/examples/read_password.rs
@@ -9,7 +9,7 @@ struct MaskingHighlighter {
 }
 
 impl Highlighter for MaskingHighlighter {
-    #[cfg(any(not(feature = "split-highlight"), feature = "ansi-str"))]
+    #[cfg(not(feature = "split-highlight"))]
     fn highlight<'l>(&mut self, line: &'l str, _pos: usize) -> std::borrow::Cow<'l, str> {
         use unicode_width::UnicodeWidthStr;
         if self.masking {
@@ -19,21 +19,21 @@ impl Highlighter for MaskingHighlighter {
         }
     }
 
-    #[cfg(all(feature = "split-highlight", not(feature = "ansi-str")))]
+    #[cfg(feature = "split-highlight")]
     fn highlight_line<'l>(
-        &self,
+        &mut self,
         line: &'l str,
         _pos: usize,
     ) -> impl Iterator<Item = impl 'l + rustyline::highlight::StyledBlock> {
         use unicode_width::UnicodeWidthStr;
         if self.masking {
             vec![(
-                rustyline::highlight::AnsiStyle::default(),
+                (),
                 " ".repeat(line.width()),
             )]
             .into_iter()
         } else {
-            vec![(rustyline::highlight::AnsiStyle::default(), line.to_owned())].into_iter()
+            vec![((), line.to_owned())].into_iter()
         }
     }
 

--- a/examples/read_password.rs
+++ b/examples/read_password.rs
@@ -27,11 +27,7 @@ impl Highlighter for MaskingHighlighter {
     ) -> impl Iterator<Item = impl 'l + rustyline::highlight::StyledBlock> {
         use unicode_width::UnicodeWidthStr;
         if self.masking {
-            vec![(
-                (),
-                " ".repeat(line.width()),
-            )]
-            .into_iter()
+            vec![((), " ".repeat(line.width()))].into_iter()
         } else {
             vec![((), line.to_owned())].into_iter()
         }

--- a/examples/read_password.rs
+++ b/examples/read_password.rs
@@ -9,27 +9,16 @@ struct MaskingHighlighter {
 }
 
 impl Highlighter for MaskingHighlighter {
-    #[cfg(not(feature = "split-highlight"))]
-    fn highlight<'l>(&mut self, line: &'l str, _pos: usize) -> std::borrow::Cow<'l, str> {
+    fn highlight<'b, 's: 'b, 'l: 'b>(
+        &'s mut self,
+        line: &'l str,
+        pos: usize,
+    ) -> std::borrow::Cow<'b, str> {
         use unicode_width::UnicodeWidthStr;
         if self.masking {
             std::borrow::Cow::Owned(" ".repeat(line.width()))
         } else {
             std::borrow::Cow::Borrowed(line)
-        }
-    }
-
-    #[cfg(feature = "split-highlight")]
-    fn highlight_line<'l>(
-        &mut self,
-        line: &'l str,
-        _pos: usize,
-    ) -> impl Iterator<Item = impl 'l + rustyline::highlight::StyledBlock> {
-        use unicode_width::UnicodeWidthStr;
-        if self.masking {
-            vec![((), " ".repeat(line.width()))].into_iter()
-        } else {
-            vec![((), line.to_owned())].into_iter()
         }
     }
 

--- a/examples/read_password.rs
+++ b/examples/read_password.rs
@@ -10,7 +10,7 @@ struct MaskingHighlighter {
 
 impl Highlighter for MaskingHighlighter {
     #[cfg(any(not(feature = "split-highlight"), feature = "ansi-str"))]
-    fn highlight<'l>(&self, line: &'l str, _pos: usize) -> std::borrow::Cow<'l, str> {
+    fn highlight<'l>(&mut self, line: &'l str, _pos: usize) -> std::borrow::Cow<'l, str> {
         use unicode_width::UnicodeWidthStr;
         if self.masking {
             std::borrow::Cow::Owned(" ".repeat(line.width()))
@@ -37,7 +37,7 @@ impl Highlighter for MaskingHighlighter {
         }
     }
 
-    fn highlight_char(&self, _line: &str, _pos: usize, _forced: bool) -> bool {
+    fn highlight_char(&mut self, _line: &str, _pos: usize, _forced: bool) -> bool {
         self.masking
     }
 }
@@ -45,13 +45,12 @@ impl Highlighter for MaskingHighlighter {
 fn main() -> Result<()> {
     println!("This is just a hack. Reading passwords securely requires more than that.");
     let h = MaskingHighlighter { masking: false };
-    let mut rl = Editor::new()?;
-    rl.set_helper(Some(h));
+    let mut rl = Editor::new(h)?;
 
     let username = rl.readline("Username:")?;
     println!("Username: {username}");
 
-    rl.helper_mut().expect("No helper").masking = true;
+    rl.helper_mut().masking = true;
     rl.set_color_mode(ColorMode::Forced); // force masking
     rl.set_auto_add_history(false); // make sure password is not added to history
     let mut guard = rl.set_cursor_visibility(false)?;

--- a/examples/sqlite_history.rs
+++ b/examples/sqlite_history.rs
@@ -9,7 +9,7 @@ fn main() -> Result<()> {
         // file
         rustyline::sqlite_history::SQLiteHistory::open(config, "history.sqlite3")?
     };
-    let mut rl: Editor<(), _> = Editor::with_history(config, history)?;
+    let mut rl: Editor<(), _> = Editor::with_history(config, history, ())?;
     loop {
         let line = rl.readline("> ")?;
         println!("{line}");

--- a/rustyline-derive/src/lib.rs
+++ b/rustyline-derive/src/lib.rs
@@ -102,12 +102,12 @@ pub fn highlighter_macro_derive(input: TokenStream) -> TokenStream {
         quote! {
             #[automatically_derived]
             impl #impl_generics ::rustyline::highlight::Highlighter for #name #ty_generics #where_clause {
-                #[cfg(any(not(feature = "split-highlight"), feature = "ansi-str"))]
+                #[cfg(not(feature = "split-highlight"))]
                 fn highlight<'l>(&mut self, line: &'l str, pos: usize) -> ::std::borrow::Cow<'l, str> {
                     ::rustyline::highlight::Highlighter::highlight(&mut self.#field_name_or_index, line, pos)
                 }
 
-                #[cfg(all(feature = "split-highlight", not(feature = "ansi-str")))]
+                #[cfg(feature = "split-highlight")]
                 fn highlight_line<'l>(
                     &mut self,
                     line: &'l str,

--- a/rustyline-derive/src/lib.rs
+++ b/rustyline-derive/src/lib.rs
@@ -102,37 +102,27 @@ pub fn highlighter_macro_derive(input: TokenStream) -> TokenStream {
         quote! {
             #[automatically_derived]
             impl #impl_generics ::rustyline::highlight::Highlighter for #name #ty_generics #where_clause {
-                #[cfg(not(feature = "split-highlight"))]
-                fn highlight<'l>(&mut self, line: &'l str, pos: usize) -> ::std::borrow::Cow<'l, str> {
+                fn highlight<'b,'h:'b,'l:'b>(&'h mut self, line: &'l str, pos: usize) -> impl 'b + ::rustyline::highlight::DisplayOnce {
                     ::rustyline::highlight::Highlighter::highlight(&mut self.#field_name_or_index, line, pos)
-                }
-
-                #[cfg(feature = "split-highlight")]
-                fn highlight_line<'l>(
-                    &mut self,
-                    line: &'l str,
-                    pos: usize,
-                ) -> impl Iterator<Item = impl 'l + ::rustyline::highlight::StyledBlock> {
-                    ::rustyline::highlight::Highlighter::highlight_line(&mut self.#field_name_or_index, line, pos)
                 }
 
                 fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
                     &'s mut self,
                     prompt: &'p str,
                     default: bool,
-                ) -> ::std::borrow::Cow<'b, str> {
+                ) -> impl 'b + ::rustyline::highlight::DisplayOnce {
                     ::rustyline::highlight::Highlighter::highlight_prompt(&mut self.#field_name_or_index, prompt, default)
                 }
 
-                fn highlight_hint<'h>(&mut self, hint: &'h str) -> ::std::borrow::Cow<'h, str> {
+                fn highlight_hint<'b, 's: 'b, 'h: 'b>(&'s mut self, hint: &'h str) -> impl 'b + ::rustyline::highlight::DisplayOnce {
                     ::rustyline::highlight::Highlighter::highlight_hint(&mut self.#field_name_or_index, hint)
                 }
 
-                fn highlight_candidate<'c>(
-                    &mut self,
+                fn highlight_candidate<'b, 's: 'b, 'c: 'b>(
+                    &'s mut self,
                     candidate: &'c str,
                     completion: ::rustyline::config::CompletionType,
-                ) -> ::std::borrow::Cow<'c, str> {
+                ) -> impl 'b + ::rustyline::highlight::DisplayOnce {
                     ::rustyline::highlight::Highlighter::highlight_candidate(&mut self.#field_name_or_index, candidate, completion)
                 }
 

--- a/rustyline-derive/src/lib.rs
+++ b/rustyline-derive/src/lib.rs
@@ -51,16 +51,16 @@ pub fn completer_macro_derive(input: TokenStream) -> TokenStream {
                 type Candidate = <#field_type as ::rustyline::completion::Completer>::Candidate;
 
                 fn complete(
-                    &self,
+                    &mut self,
                     line: &str,
                     pos: usize,
                     ctx: &::rustyline::Context<'_>,
                 ) -> ::rustyline::Result<(usize, ::std::vec::Vec<Self::Candidate>)> {
-                    ::rustyline::completion::Completer::complete(&self.#field_name_or_index, line, pos, ctx)
+                    ::rustyline::completion::Completer::complete(&mut self.#field_name_or_index, line, pos, ctx)
                 }
 
-                fn update(&self, line: &mut ::rustyline::line_buffer::LineBuffer, start: usize, elected: &str, cl: &mut ::rustyline::Changeset) {
-                    ::rustyline::completion::Completer::update(&self.#field_name_or_index, line, start, elected, cl)
+                fn update(&mut self, line: &mut ::rustyline::line_buffer::LineBuffer, start: usize, elected: &str, cl: &mut ::rustyline::Changeset) {
+                    ::rustyline::completion::Completer::update(&mut self.#field_name_or_index, line, start, elected, cl)
                 }
             }
         }
@@ -103,41 +103,41 @@ pub fn highlighter_macro_derive(input: TokenStream) -> TokenStream {
             #[automatically_derived]
             impl #impl_generics ::rustyline::highlight::Highlighter for #name #ty_generics #where_clause {
                 #[cfg(any(not(feature = "split-highlight"), feature = "ansi-str"))]
-                fn highlight<'l>(&self, line: &'l str, pos: usize) -> ::std::borrow::Cow<'l, str> {
-                    ::rustyline::highlight::Highlighter::highlight(&self.#field_name_or_index, line, pos)
+                fn highlight<'l>(&mut self, line: &'l str, pos: usize) -> ::std::borrow::Cow<'l, str> {
+                    ::rustyline::highlight::Highlighter::highlight(&mut self.#field_name_or_index, line, pos)
                 }
 
                 #[cfg(all(feature = "split-highlight", not(feature = "ansi-str")))]
                 fn highlight_line<'l>(
-                    &self,
+                    &mut self,
                     line: &'l str,
                     pos: usize,
                 ) -> impl Iterator<Item = impl 'l + ::rustyline::highlight::StyledBlock> {
-                    ::rustyline::highlight::Highlighter::highlight_line(&self.#field_name_or_index, line, pos)
+                    ::rustyline::highlight::Highlighter::highlight_line(&mut self.#field_name_or_index, line, pos)
                 }
 
                 fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
-                    &'s self,
+                    &'s mut self,
                     prompt: &'p str,
                     default: bool,
                 ) -> ::std::borrow::Cow<'b, str> {
-                    ::rustyline::highlight::Highlighter::highlight_prompt(&self.#field_name_or_index, prompt, default)
+                    ::rustyline::highlight::Highlighter::highlight_prompt(&mut self.#field_name_or_index, prompt, default)
                 }
 
-                fn highlight_hint<'h>(&self, hint: &'h str) -> ::std::borrow::Cow<'h, str> {
-                    ::rustyline::highlight::Highlighter::highlight_hint(&self.#field_name_or_index, hint)
+                fn highlight_hint<'h>(&mut self, hint: &'h str) -> ::std::borrow::Cow<'h, str> {
+                    ::rustyline::highlight::Highlighter::highlight_hint(&mut self.#field_name_or_index, hint)
                 }
 
                 fn highlight_candidate<'c>(
-                    &self,
+                    &mut self,
                     candidate: &'c str,
                     completion: ::rustyline::config::CompletionType,
                 ) -> ::std::borrow::Cow<'c, str> {
-                    ::rustyline::highlight::Highlighter::highlight_candidate(&self.#field_name_or_index, candidate, completion)
+                    ::rustyline::highlight::Highlighter::highlight_candidate(&mut self.#field_name_or_index, candidate, completion)
                 }
 
-                fn highlight_char(&self, line: &str, pos: usize, forced: bool) -> bool {
-                    ::rustyline::highlight::Highlighter::highlight_char(&self.#field_name_or_index, line, pos, forced)
+                fn highlight_char(&mut self, line: &str, pos: usize, forced: bool) -> bool {
+                    ::rustyline::highlight::Highlighter::highlight_char(&mut self.#field_name_or_index, line, pos, forced)
                 }
             }
         }
@@ -166,8 +166,8 @@ pub fn hinter_macro_derive(input: TokenStream) -> TokenStream {
             impl #impl_generics ::rustyline::hint::Hinter for #name #ty_generics #where_clause {
                 type Hint = <#field_type as ::rustyline::hint::Hinter>::Hint;
 
-                fn hint(&self, line: &str, pos: usize, ctx: &::rustyline::Context<'_>) -> ::std::option::Option<Self::Hint> {
-                    ::rustyline::hint::Hinter::hint(&self.#field_name_or_index, line, pos, ctx)
+                fn hint(&mut self, line: &str, pos: usize, ctx: &::rustyline::Context<'_>) -> ::std::option::Option<Self::Hint> {
+                    ::rustyline::hint::Hinter::hint(&mut self.#field_name_or_index, line, pos, ctx)
                 }
             }
         }
@@ -195,14 +195,14 @@ pub fn validator_macro_derive(input: TokenStream) -> TokenStream {
             #[automatically_derived]
             impl #impl_generics ::rustyline::validate::Validator for #name #ty_generics #where_clause {
                 fn validate(
-                    &self,
+                    &mut self,
                     ctx: &mut ::rustyline::validate::ValidationContext,
                 ) -> ::rustyline::Result<::rustyline::validate::ValidationResult> {
-                    ::rustyline::validate::Validator::validate(&self.#field_name_or_index, ctx)
+                    ::rustyline::validate::Validator::validate(&mut self.#field_name_or_index, ctx)
                 }
 
-                fn validate_while_typing(&self) -> bool {
-                    ::rustyline::validate::Validator::validate_while_typing(&self.#field_name_or_index)
+                fn validate_while_typing(&mut self) -> bool {
+                    ::rustyline::validate::Validator::validate_while_typing(&mut self.#field_name_or_index)
                 }
             }
         }

--- a/src/command.rs
+++ b/src/command.rs
@@ -133,6 +133,7 @@ pub fn execute<H: Helper>(
         Cmd::AcceptLine | Cmd::AcceptOrInsertLine { .. } => {
             let validation_result = s.validate()?;
             let valid = validation_result.is_valid();
+            let incomplete = validation_result.is_incomplete();
             let end = s.line.is_end_of_input();
             match (cmd, valid, end) {
                 (Cmd::AcceptLine, ..)
@@ -150,6 +151,9 @@ pub fn execute<H: Helper>(
                 | (Cmd::AcceptOrInsertLine { .. }, true, false) => {
                     if valid || !validation_result.has_message() {
                         s.edit_insert('\n', 1)?;
+                    }
+                    if let Some(indent) = incomplete {
+                        s.edit_insert(' ', indent)?;
                     }
                 }
                 _ => unreachable!(),

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -90,7 +90,7 @@ pub trait Completer {
     ///
     /// ("ls /usr/loc", 11) => Ok((3, vec!["/usr/local/"]))
     fn complete(
-        &self, // FIXME should be `&mut self`
+        &mut self, // FIXME should be `&mut self`
         line: &str,
         pos: usize,
         ctx: &Context<'_>,
@@ -99,7 +99,7 @@ pub trait Completer {
         Ok((0, Vec::with_capacity(0)))
     }
     /// Updates the edited `line` with the `elected` candidate.
-    fn update(&self, line: &mut LineBuffer, start: usize, elected: &str, cl: &mut Changeset) {
+    fn update(&mut self, line: &mut LineBuffer, start: usize, elected: &str, cl: &mut Changeset) {
         let end = line.pos();
         line.replace(start..end, elected, cl);
     }
@@ -108,16 +108,22 @@ pub trait Completer {
 impl Completer for () {
     type Candidate = String;
 
-    fn update(&self, _line: &mut LineBuffer, _start: usize, _elected: &str, _cl: &mut Changeset) {
+    fn update(
+        &mut self,
+        _line: &mut LineBuffer,
+        _start: usize,
+        _elected: &str,
+        _cl: &mut Changeset,
+    ) {
         unreachable!();
     }
 }
 
-impl<'c, C: ?Sized + Completer> Completer for &'c C {
+impl<'c, C: ?Sized + Completer> Completer for &'c mut C {
     type Candidate = C::Candidate;
 
     fn complete(
-        &self,
+        &mut self,
         line: &str,
         pos: usize,
         ctx: &Context<'_>,
@@ -125,31 +131,31 @@ impl<'c, C: ?Sized + Completer> Completer for &'c C {
         (**self).complete(line, pos, ctx)
     }
 
-    fn update(&self, line: &mut LineBuffer, start: usize, elected: &str, cl: &mut Changeset) {
+    fn update(&mut self, line: &mut LineBuffer, start: usize, elected: &str, cl: &mut Changeset) {
         (**self).update(line, start, elected, cl);
     }
 }
-macro_rules! box_completer {
-    ($($id: ident)*) => {
-        $(
-            impl<C: ?Sized + Completer> Completer for $id<C> {
-                type Candidate = C::Candidate;
+// macro_rules! box_completer {
+//     ($($id: ident)*) => {
+//         $(
+//             impl<C: ?Sized + Completer> Completer for $id<C> {
+//                 type Candidate = C::Candidate;
 
-                fn complete(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Result<(usize, Vec<Self::Candidate>)> {
-                    (**self).complete(line, pos, ctx)
-                }
-                fn update(&self, line: &mut LineBuffer, start: usize, elected: &str, cl: &mut Changeset) {
-                    (**self).update(line, start, elected, cl)
-                }
-            }
-        )*
-    }
-}
+//                 fn complete(&mut self, line: &str, pos: usize, ctx: &Context<'_>) -> Result<(usize, Vec<Self::Candidate>)> {
+//                     (**self).complete(line, pos, ctx)
+//                 }
+//                 fn update(&mut self, line: &mut LineBuffer, start: usize, elected: &str, cl: &mut Changeset) {
+//                     (**self).update(line, start, elected, cl)
+//                 }
+//             }
+//         )*
+//     }
+// }
 
 use crate::undo::Changeset;
 use std::rc::Rc;
-use std::sync::Arc;
-box_completer! { Box Rc Arc }
+// use std::sync::Arc;
+// box_completer! { Box Rc Arc }
 
 /// A `Completer` for file and folder names.
 pub struct FilenameCompleter {
@@ -257,7 +263,12 @@ impl Default for FilenameCompleter {
 impl Completer for FilenameCompleter {
     type Candidate = Pair;
 
-    fn complete(&self, line: &str, pos: usize, _ctx: &Context<'_>) -> Result<(usize, Vec<Pair>)> {
+    fn complete(
+        &mut self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> Result<(usize, Vec<Pair>)> {
         self.complete_path(line, pos)
     }
 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -51,7 +51,11 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
         helper: &'out mut H,
         ctx: Context<'out>,
     ) -> Self {
-        let prompt_size = out.calculate_position(prompt, Position::default(), helper.continuation_prompt_width(prompt));
+        let prompt_size = out.calculate_position(
+            prompt,
+            Position::default(),
+            helper.continuation_prompt_width(prompt),
+        );
         Self {
             out,
             prompt,
@@ -86,9 +90,11 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
                 if new_cols != old_cols
                     && (self.layout.end.row > 0 || self.layout.end.col >= new_cols)
                 {
-                    self.prompt_size =
-                        self.out
-                            .calculate_position(self.prompt, Position::default(), self.helper.continuation_prompt_width(self.prompt));
+                    self.prompt_size = self.out.calculate_position(
+                        self.prompt,
+                        Position::default(),
+                        self.helper.continuation_prompt_width(self.prompt),
+                    );
                     self.refresh_line()?;
                 }
                 continue;
@@ -286,7 +292,11 @@ impl<'out, 'prompt, H: Helper> Refresher for State<'out, 'prompt, H> {
     }
 
     fn refresh_prompt_and_line(&mut self, prompt: &str) -> Result<()> {
-        let prompt_size = self.out.calculate_position(prompt, Position::default(), self.helper.continuation_prompt_width(prompt));
+        let prompt_size = self.out.calculate_position(
+            prompt,
+            Position::default(),
+            self.helper.continuation_prompt_width(prompt),
+        );
         self.update_after_edit();
         self.hint();
         self.highlight_char();

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -69,14 +69,6 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
         }
     }
 
-    // pub fn highlighter(&mut self) -> Option<&mut H> {
-    //     if self.out.colors_enabled() {
-    //         Some(self.helper)
-    //     } else {
-    //         None
-    //     }
-    // }
-
     pub fn next_cmd(
         &mut self,
         input_state: &mut InputState,
@@ -178,7 +170,6 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
 
         debug!(target: "rustyline", "old layout: {:?}", self.layout);
         debug!(target: "rustyline", "new layout: {:?}", new_layout);
-        // if self.out.colors_enabled() {
         self.out.refresh_line(
             prompt,
             &self.line,

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -204,23 +204,23 @@ impl<'out, 'prompt, H: Helper> State<'out, 'prompt, H> {
     }
 
     fn highlight_char(&mut self) -> bool {
-        // if let Some(highlighter) = self.highlighter() {
-        let highlight_char =
-            self.helper
-                .highlight_char(&self.line, self.line.pos(), self.forced_refresh);
-        if highlight_char {
-            self.highlight_char = true;
-            true
-        } else if self.highlight_char {
-            // previously highlighted => force a full refresh
-            self.highlight_char = false;
-            true
+        if self.out.colors_enabled() {
+            let highlight_char =
+                self.helper
+                    .highlight_char(&self.line, self.line.pos(), self.forced_refresh);
+            if highlight_char {
+                self.highlight_char = true;
+                true
+            } else if self.highlight_char {
+                // previously highlighted => force a full refresh
+                self.highlight_char = false;
+                true
+            } else {
+                false
+            }
         } else {
             false
         }
-        // } else {
-        //     false
-        // }
     }
 
     pub fn is_default_prompt(&self) -> bool {

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,7 +125,7 @@ impl From<std::string::FromUtf8Error> for ReadlineError {
     }
 }
 
-#[cfg(any(unix, all(feature = "split-highlight", not(feature = "ansi-str"))))]
+#[cfg(unix)]
 impl From<fmt::Error> for ReadlineError {
     fn from(err: fmt::Error) -> Self {
         Self::Io(io::Error::new(io::ErrorKind::Other, err))

--- a/src/hint.rs
+++ b/src/hint.rs
@@ -30,7 +30,7 @@ pub trait Hinter {
     /// returns the string that should be displayed or `None`
     /// if no hint is available for the text the user currently typed.
     // TODO Validate: called while editing line but not while moving cursor.
-    fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<Self::Hint> {
+    fn hint(&mut self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<Self::Hint> {
         let _ = (line, pos, ctx);
         None
     }
@@ -40,10 +40,10 @@ impl Hinter for () {
     type Hint = String;
 }
 
-impl<'r, H: ?Sized + Hinter> Hinter for &'r H {
+impl<'r, H: ?Sized + Hinter> Hinter for &'r mut H {
     type Hint = H::Hint;
 
-    fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<Self::Hint> {
+    fn hint(&mut self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<Self::Hint> {
         (**self).hint(line, pos, ctx)
     }
 }
@@ -63,7 +63,7 @@ impl HistoryHinter {
 impl Hinter for HistoryHinter {
     type Hint = String;
 
-    fn hint(&self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
+    fn hint(&mut self, line: &str, pos: usize, ctx: &Context<'_>) -> Option<String> {
         if line.is_empty() || pos < line.len() {
             return None;
         }
@@ -96,7 +96,7 @@ mod test {
     pub fn empty_history() {
         let history = DefaultHistory::new();
         let ctx = Context::new(&history);
-        let hinter = HistoryHinter {};
+        let mut hinter = HistoryHinter {};
         let hint = hinter.hint("test", 4, &ctx);
         assert_eq!(None, hint);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,7 +588,7 @@ impl<'h, H: Helper> Helper for &'h mut H {
         (**self).update_after_edit(line, pos, forced_refresh)
     }
     fn update_after_move_cursor(&mut self, line: &str, pos: usize) {
-        (**self).update_after_move_cursor(line,pos)
+        (**self).update_after_move_cursor(line, pos)
     }
     fn continuation_prompt_width<'b, 's: 'b, 'p: 'b>(&'s self, prompt: &'p str) -> usize {
         (**self).continuation_prompt_width(prompt)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,15 +338,14 @@ fn page_completions<C: Candidate, H: Helper>(
             if i < candidates.len() {
                 let candidate = &candidates[i].display();
                 let width = candidate.width();
-                ab.push_str(
-                    &s.helper
-                        .highlight_candidate(candidate, CompletionType::List),
-                );
-                // if let Some(highlighter) = s.highlighter() {
-                //     ab.push_str(&highlighter.highlight_candidate(candidate, CompletionType::List));
-                // } else {
-                //     ab.push_str(candidate);
-                // }
+                if s.out.colors_enabled() {
+                    ab.push_str(
+                        &s.helper
+                            .highlight_candidate(candidate, CompletionType::List),
+                    );
+                } else {
+                    ab.push_str(candidate);
+                }
                 if ((col + 1) * num_rows) + row < candidates.len() {
                     for _ in width..max_width {
                         ab.push(' ');

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -643,12 +643,16 @@ pub type DefaultEditor = Editor<(), DefaultHistory>;
 
 #[allow(clippy::new_without_default)]
 impl<H: Helper> Editor<H, DefaultHistory> {
-    /// Create an editor with the default configuration
+    /// Create an editor with a helper and the default configuration.
+    /// 
+    /// Use `new(())` for default Helper.
     pub fn new(helper: H) -> Result<Self> {
         Self::with_config(Config::default(), helper)
     }
 
-    /// Create an editor with a specific configuration.
+    /// Create an editor with a specific configuration and a helper.
+    /// 
+    /// Use `with_config(config,())` for default Helper.
     pub fn with_config(config: Config, helper: H) -> Result<Self> {
         Self::with_history(config, DefaultHistory::with_config(config), helper)
     }
@@ -883,9 +887,10 @@ impl<H: Helper, I: History> Editor<H, I> {
         &self.history
     }
 
-    /// Register a callback function to be called for tab-completion
-    /// or to show hints to the user at the right of the prompt.
-    #[deprecated = "reason"]
+    /// This will do nothing and will remove in future version.
+    /// 
+    /// Now we should specify the helper when create the editor
+    #[deprecated = "specify the helper when crate the editor"]
     pub fn set_helper(&mut self) {}
 
     /// Return a mutable reference to the helper.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -572,11 +572,28 @@ where
     fn update_after_move_cursor(&mut self, line: &str, pos: usize) {
         _ = (line, pos);
     }
+
+    /// Return the width of continuation prompt,
+    /// the continuation prompt should be implemented at highlight
+    fn continuation_prompt_width<'b, 's: 'b, 'p: 'b>(&'s self, prompt: &'p str) -> usize {
+        _ = prompt;
+        0
+    }
 }
 
 impl Helper for () {}
 
-impl<'h, H: Helper> Helper for &'h mut H {}
+impl<'h, H: Helper> Helper for &'h mut H {
+    fn update_after_edit(&mut self, line: &str, pos: usize, forced_refresh: bool) {
+        (**self).update_after_edit(line, pos, forced_refresh)
+    }
+    fn update_after_move_cursor(&mut self, line: &str, pos: usize) {
+        (**self).update_after_move_cursor(line,pos)
+    }
+    fn continuation_prompt_width<'b, 's: 'b, 'p: 'b>(&'s self, prompt: &'p str) -> usize {
+        (**self).continuation_prompt_width(prompt)
+    }
+}
 
 /// Completion/suggestion context
 pub struct Context<'h> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ use std::io::{self, BufRead, Write};
 use std::path::Path;
 use std::result;
 
+use highlight::DisplayOnce;
 use log::debug;
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
@@ -339,10 +340,11 @@ fn page_completions<C: Candidate, H: Helper>(
                 let candidate = &candidates[i].display();
                 let width = candidate.width();
                 if s.out.colors_enabled() {
-                    ab.push_str(
-                        &s.helper
+                    DisplayOnce::fmt(
+                        s.helper
                             .highlight_candidate(candidate, CompletionType::List),
-                    );
+                        &mut ab,
+                    )?;
                 } else {
                     ab.push_str(candidate);
                 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -20,7 +20,7 @@ mod vi_insert;
 
 fn init_editor(mode: EditMode, keys: &[KeyEvent]) -> DefaultEditor {
     let config = Config::builder().edit_mode(mode).build();
-    let mut editor = DefaultEditor::with_config(config).unwrap();
+    let mut editor = DefaultEditor::with_config(config, ()).unwrap();
     editor.term.keys.extend(keys.iter().copied());
     editor
 }
@@ -30,7 +30,7 @@ impl Completer for SimpleCompleter {
     type Candidate = String;
 
     fn complete(
-        &self,
+        &mut self,
         line: &str,
         _pos: usize,
         _ctx: &Context<'_>,
@@ -50,7 +50,7 @@ impl Completer for SimpleCompleter {
 impl Hinter for SimpleCompleter {
     type Hint = String;
 
-    fn hint(&self, _line: &str, _pos: usize, _ctx: &Context<'_>) -> Option<Self::Hint> {
+    fn hint(&mut self, _line: &str, _pos: usize, _ctx: &Context<'_>) -> Option<Self::Hint> {
         None
     }
 }
@@ -63,8 +63,8 @@ impl Validator for SimpleCompleter {}
 fn complete_line() {
     let mut out = Sink::default();
     let history = crate::history::DefaultHistory::new();
-    let helper = Some(SimpleCompleter);
-    let mut s = init_state(&mut out, "rus", 3, helper.as_ref(), &history);
+    let mut helper = SimpleCompleter;
+    let mut s = init_state(&mut out, "rus", 3, &mut helper, &history);
     let config = Config::default();
     let bindings = Bindings::new();
     let mut input_state = InputState::new(&config, &bindings);
@@ -85,8 +85,8 @@ fn complete_line() {
 fn complete_symbol() {
     let mut out = Sink::default();
     let history = crate::history::DefaultHistory::new();
-    let helper = Some(SimpleCompleter);
-    let mut s = init_state(&mut out, "\\hbar", 5, helper.as_ref(), &history);
+    let mut helper = SimpleCompleter;
+    let mut s = init_state(&mut out, "\\hbar", 5, &mut helper, &history);
     let config = Config::builder()
         .completion_type(CompletionType::List)
         .build();
@@ -188,7 +188,7 @@ fn test_readline_direct() {
     let output = readline_direct(
         Cursor::new("([)\n\u{0008}\n\n\r\n])".as_bytes()),
         Cursor::new(&mut write_buf),
-        &Some(crate::validate::MatchingBracketValidator::new()),
+        &mut crate::validate::MatchingBracketValidator::new(),
     );
 
     assert_eq!(

--- a/src/tty/mod.rs
+++ b/src/tty/mod.rs
@@ -54,7 +54,7 @@ pub trait Renderer {
         hint: Option<&str>,
         old_layout: &Layout,
         new_layout: &Layout,
-        highlighter: Option<&H>,
+        highlighter: &mut H,
     ) -> Result<()>;
 
     /// Compute layout for rendering prompt + line + some info (either hint,
@@ -133,7 +133,7 @@ impl<'a, R: Renderer + ?Sized> Renderer for &'a mut R {
         hint: Option<&str>,
         old_layout: &Layout,
         new_layout: &Layout,
-        highlighter: Option<&H>,
+        highlighter: &mut H,
     ) -> Result<()> {
         (**self).refresh_line(prompt, line, hint, old_layout, new_layout, highlighter)
     }

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -107,7 +107,7 @@ impl Renderer for Sink {
         _hint: Option<&str>,
         _old_layout: &Layout,
         _new_layout: &Layout,
-        _highlighter: Option<&H>,
+        _highlighter: &mut H,
     ) -> Result<()> {
         Ok(())
     }

--- a/src/tty/test.rs
+++ b/src/tty/test.rs
@@ -112,7 +112,13 @@ impl Renderer for Sink {
         Ok(())
     }
 
-    fn calculate_position(&self, s: &str, orig: Position) -> Position {
+    fn calculate_position(
+        &self,
+        s: &str,
+        orig: Position,
+        continuation_prompt_width: usize,
+    ) -> Position {
+        _ = continuation_prompt_width;
         let mut pos = orig;
         pos.col += s.len();
         pos

--- a/src/tty/windows.rs
+++ b/src/tty/windows.rs
@@ -444,7 +444,7 @@ impl Renderer for ConsoleRenderer {
 
         self.buffer.clear();
         let mut col = 0;
-        if let Some(highlighter) = highlighter {
+        if self.colors_enabled() {
             // TODO handle ansi escape code (SetConsoleTextAttribute)
             // append the prompt
             col = self.wrap_at_eol(&highlighter.highlight_prompt(prompt, default_prompt), col);
@@ -476,12 +476,10 @@ impl Renderer for ConsoleRenderer {
             // append the input line
             self.buffer.push_str(line);
         }
-        // append hint
+        // display hint
         if let Some(hint) = hint {
-            if let Some(highlighter) = highlighter {
+            if self.colors_enabled() {
                 self.wrap_at_eol(&highlighter.highlight_hint(hint), col);
-            } else if self.colors_enabled {
-                self.wrap_at_eol(hint, col);
             } else {
                 self.buffer.push_str(hint);
             }


### PR DESCRIPTION
Hi, I believe this version is well-defined, pls take a while to review:)

1. Hardcoded continuation prompt implementation with `continuation_prompt` feature. 
See https://github.com/kkawakam/rustyline/pull/795
With example at `examples/continuation_prompt.rs`:
![demo1](https://github.com/user-attachments/assets/7e62c632-b257-4aa6-95d3-6d91fc63a672)
Also, verify with my python REPL project https://github.com/zao111222333/pyapp
![demo2](https://github.com/user-attachments/assets/c309fe68-80ce-455a-a403-83a407bb4eb3)


2. Reduce tokenizer/parser overhead
I believe the `Helper` in `Editor` should be `helper: H`, rather than `helper: Option<H>`, then we can avoid lifetime issue when using `&mut self` in `highlight`, `validate`, `complete`, ...
as you have mentioned at
https://github.com/gwenn/rustyline/blob/highlight/src/completion.rs#L93
That's a quite large breaking change, but with this change, we can reduce the overhead and only tokenizer/parser once! see:
before https://github.com/gwenn/rustyline/blob/highlight/src/lib.rs#L543
now https://github.com/zao111222333/rustyline/blob/highlight/src/lib.rs#L547-L576